### PR TITLE
Add dependencies to gemspec, add Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+# A sample Gemfile
+source "https://rubygems.org"
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,23 @@
+PATH
+  remote: .
+  specs:
+    csvr (1.0.0)
+      sqlite3
+      thor
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    minitest (5.7.0)
+    sqlite3 (1.3.10)
+    thor (0.19.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  csvr!
+  minitest
+
+BUNDLED WITH
+   1.10.5

--- a/csvr.gemspec
+++ b/csvr.gemspec
@@ -11,4 +11,8 @@ Gem::Specification.new do |gem|
 	gem.executables << 'csvr'
 	gem.homepage = 'https://github.com/sm1th-/csvr.git'
 	gem.license = 'MIT'
+
+	gem.add_runtime_dependency "sqlite3"
+	gem.add_runtime_dependency "thor"
+	gem.add_development_dependency "minitest"
 end


### PR DESCRIPTION
Wanted to introduce you to the Gemfile and gemspec dependencies. When I pulled your code down, I couldn't quite run it, because I didn't have the necessary dependencies, namely, sqlite3, thor and minitest. There was no way for me to know what was missing versus available, except by running the code and seeing where it failed each time, installing the missing gem one by one on failures.

By adding your gem's dependencies to your gemspec, it ensures that these gems will also be installed when a user installs *your* gem.

When pulling the source, you'd use the command `bundle install` to install the correct gems.

When you pull a new gem into your project, don't forget to add it to the gemspec!

More information:
* http://bundler.io/rubygems.html
* http://guides.rubygems.org/patterns/#declaring-dependencies